### PR TITLE
fix: bump github actions to node24 runtimes

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -16,11 +16,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 16
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: node-modules
           key: node-modules-${{ hashFiles('yarn.lock') }}

--- a/action.yaml
+++ b/action.yaml
@@ -5,5 +5,5 @@ inputs:
   version:
     default: latest
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/setup-govulncheck/index.js'


### PR DESCRIPTION
GitHub removes Node ≤20 action runtimes from runners on 2026-09-16 (forced Node 24 default since 2026-06-16) — [changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Actions updated to their Node 24 releases:

- `actions/cache` v4 → v5
- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- first-party `action.yaml` runtime → node24